### PR TITLE
fix: incomplete homepage data on language change

### DIFF
--- a/lib/Helpers/format.dart
+++ b/lib/Helpers/format.dart
@@ -408,7 +408,15 @@ class FormatResponse {
       for (int i = 0; i < promoList.length; i++) {
         data[promoList[i]] = await formatSongsInList(data[promoList[i]]);
       }
-      data["promo_lists"] = promoList;
+      data["collections"] = [
+        "new_trending",
+        "charts",
+        "new_albums",
+        "top_playlists",
+        // "city_mod",
+        // "artist_recos",
+        ...promoList
+      ];
     } catch (err) {
       print(err);
     }

--- a/lib/Screens/Common/song_list.dart
+++ b/lib/Screens/Common/song_list.dart
@@ -32,7 +32,7 @@ class _SongsListPageState extends State<SongsListPage> {
     if (!status) {
       status = true;
       switch (widget.listItem['type']) {
-        case 'song':
+        case 'songs':
           SaavnAPI()
               .fetchSongSearchResults(widget.listItem['id'], '20')
               .then((value) {

--- a/lib/Screens/Home/saavn.dart
+++ b/lib/Screens/Home/saavn.dart
@@ -9,7 +9,9 @@ bool fetched = false;
 List preferredLanguage =
     Hive.box('settings').get('preferredLanguage') ?? ['Hindi'];
 Map data = Hive.box('cache').get('homepage', defaultValue: {});
-List lists = ["recent", ...data["collections"]];
+List lists = data["collections"] != null
+    ? ["recent", ...data["collections"]]
+    : ["recent"];
 
 class SaavnHomePage extends StatefulWidget {
   @override

--- a/lib/Screens/Home/saavn.dart
+++ b/lib/Screens/Home/saavn.dart
@@ -9,15 +9,7 @@ bool fetched = false;
 List preferredLanguage =
     Hive.box('settings').get('preferredLanguage') ?? ['Hindi'];
 Map data = Hive.box('cache').get('homepage', defaultValue: {});
-List lists = [
-  "recent",
-  "new_trending",
-  "charts",
-  "new_albums",
-  "top_playlists",
-  // "city_mod",
-  // "artist_recos"
-];
+List lists = ["recent", ...data["collections"]];
 
 class SaavnHomePage extends StatefulWidget {
   @override
@@ -33,8 +25,7 @@ class _SaavnHomePageState extends State<SaavnHomePage> {
     if (recievedData != null && recievedData.isNotEmpty) {
       Hive.box('cache').put('homepage', recievedData);
       data = recievedData;
-      if (data["promo_lists"] != null)
-        lists = [...lists, ...data["promo_lists"]];
+      lists = ["recent", ...data["collections"]];
     }
     setState(() {});
   }

--- a/lib/Screens/Settings/setting.dart
+++ b/lib/Screens/Settings/setting.dart
@@ -665,6 +665,7 @@ class _SettingPageState extends State<SettingPage> {
                                                       "preferredLanguage",
                                                       checked);
                                                   homeScreen.fetched = false;
+                                                  homeScreen.lists = ["recent"];
                                                   homeScreen.preferredLanguage =
                                                       preferredLanguage;
                                                   widget.callback();


### PR DESCRIPTION
This PR:
- fixed the issue when a language is removed but related promolists were not cleared
- stores all promolists along with other homepage data to show up on startup