### PR TITLE
Improving Animation.

### DIFF
--- a/lib/CustomWidgets/custom_physics.dart
+++ b/lib/CustomWidgets/custom_physics.dart
@@ -2,8 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 
 class CustomPhysics extends ScrollPhysics {
-  const CustomPhysics({ScrollPhysics parent})
-      : super(parent: parent);
+  const CustomPhysics({ScrollPhysics parent}) : super(parent: parent);
 
   @override
   CustomPhysics applyTo(ScrollPhysics ancestor) {

--- a/lib/CustomWidgets/custom_physics.dart
+++ b/lib/CustomWidgets/custom_physics.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart';
+
+class CustomPhysics extends ScrollPhysics {
+  const CustomPhysics({ScrollPhysics parent})
+      : super(parent: parent);
+
+  @override
+  CustomPhysics applyTo(ScrollPhysics ancestor) {
+    return CustomPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  SpringDescription get spring => const SpringDescription(
+        mass: 150,
+        stiffness: 100,
+        damping: 1,
+      );
+}

--- a/lib/Screens/Home/home.dart
+++ b/lib/Screens/Home/home.dart
@@ -19,6 +19,8 @@ import 'dart:math';
 import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:package_info/package_info.dart';
+import 'package:blackhole/CustomWidgets/custom_physics.dart';
+
 
 class HomePage extends StatefulWidget {
   @override
@@ -303,6 +305,7 @@ class _HomePageState extends State<HomePage> {
               children: [
                 Expanded(
                   child: PageView(
+                    physics: CustomPhysics(),
                     onPageChanged: (indx) {
                       setState(() {
                         _selectedIndex = indx;

--- a/lib/Screens/Home/home.dart
+++ b/lib/Screens/Home/home.dart
@@ -21,8 +21,6 @@ import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:package_info/package_info.dart';
 
-
-
 class HomePage extends StatefulWidget {
   @override
   _HomePageState createState() => _HomePageState();

--- a/lib/Screens/Home/home.dart
+++ b/lib/Screens/Home/home.dart
@@ -1,4 +1,5 @@
 import 'package:blackhole/Helpers/countrycodes.dart';
+import 'package:blackhole/CustomWidgets/custom_physics.dart';
 import 'package:blackhole/CustomWidgets/gradientContainers.dart';
 import 'package:blackhole/Screens/Home/saavn.dart';
 import 'package:blackhole/Screens/Library/downloaded.dart';
@@ -19,7 +20,7 @@ import 'dart:math';
 import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:package_info/package_info.dart';
-import 'package:blackhole/CustomWidgets/custom_physics.dart';
+
 
 
 class HomePage extends StatefulWidget {

--- a/lib/Screens/Top Charts/top.dart
+++ b/lib/Screens/Top Charts/top.dart
@@ -1,3 +1,4 @@
+import 'package:blackhole/CustomWidgets/custom_physics.dart';
 import 'package:blackhole/CustomWidgets/emptyScreen.dart';
 import 'package:blackhole/Screens/Search/search.dart';
 import 'package:cached_network_image/cached_network_image.dart';
@@ -77,6 +78,7 @@ class _TopChartsState extends State<TopCharts> {
             ),
           ),
           body: TabBarView(
+            physics: CustomPhysics(),
             children: [
               TopPage(
                 region: widget.region,


### PR DESCRIPTION
First of all, Love your work! So flutter by default doesn't use the same **PageView Animation** as the Native Android's. Only after the page settles, after the animation gets over(which is ridiculously long by default) can the user scroll the list of songs, otherwise it scrolls to the next/previous page even on vertical drag. So I've done some changes to match the animation as the native android's. You can check these videos to see the difference.
[w/o changes.](https://drive.google.com/file/d/1LX_uFVXLgts3S-yPlCLKG1ay-3VPXc2M/view?usp=sharing)
[changes.](https://drive.google.com/file/d/1Lb2JUbCK4hoD1_W1ifHD815NXGXX5u-k/view?usp=sharing)

