### PR TITLE
Denied storage permissions fall-back to android/data/*blackhole

### DIFF
--- a/lib/Services/ext_storage_provider.dart
+++ b/lib/Services/ext_storage_provider.dart
@@ -70,7 +70,8 @@ class ExtStorageProvider {
             }
           }
         } else {
-          return throw 'something went wrong';
+          directory = await getExternalStorageDirectory();
+          return directory!.path;
         }
       } else if (Platform.isIOS) {
         directory = await getApplicationDocumentsDirectory();


### PR DESCRIPTION
[Issue 218](https://github.com/Sangwan5688/BlackHole/issues/218)
This might be a dirty fix but tried on my phone, works like a charm. You could probably rewrite this in a better way. I created the fix for personal use, thought might as well share. 

If user declines the storage prompt it sets the directory to android/data/com.shadow.blackhole. All the music files are then stored in this folder. 

Although user has to press reset in download settings to see the actual location. 