### PR TITLE
screen unresponsive issue while sharing

### DIFF
--- a/lib/Helpers/route_handler.dart
+++ b/lib/Helpers/route_handler.dart
@@ -63,7 +63,7 @@ class SongUrlHandler extends StatelessWidget {
   Widget build(BuildContext context) {
     SaavnAPI().getSongFromToken(token, type).then((value) {
       if (type == 'song') {
-        Navigator.push(
+        Navigator.pushReplacement(
           context,
           PageRouteBuilder(
             opaque: false,
@@ -79,7 +79,7 @@ class SongUrlHandler extends StatelessWidget {
         );
       }
       if (type == 'album' || type == 'playlist') {
-        Navigator.push(
+        Navigator.pushReplacement(
           context,
           PageRouteBuilder(
             opaque: false,
@@ -111,7 +111,7 @@ class OfflinePlayHandler extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     playOfflineSong(id).then((value) {
-      Navigator.push(
+      Navigator.pushReplacement(
         context,
         PageRouteBuilder(
           opaque: false,


### PR DESCRIPTION
when we share url to the other  user and after it opened and routed to the destinated screen , but after getting back from that screen you will notice that it will freeze the screen and the screen become unresponsive , so you have to press back button two times to solve this you can use pushreplacement which will remove the screen after route and hence solve the issue please check.