### PR TITLE
Implementing autoscroll feature

### DIFF
--- a/lib/Screens/Player/audioplayer.dart
+++ b/lib/Screens/Player/audioplayer.dart
@@ -1162,6 +1162,32 @@ class NowPlayingStream extends StatelessWidget {
     this.headHeight = 50,
   });
 
+  void _updateScrollController(
+    ScrollController? _controller,
+    int? itemIndex,
+    int queuePosition,
+    queue,
+  ) {
+    if (queuePosition > 3) {
+      _controller?.animateTo(
+        itemIndex! * 72 + 12,
+        curve: Curves.linear,
+        duration: const Duration(
+          milliseconds: 350,
+        ),
+      );
+    } else if (queue.length - queuePosition < 5) {
+      _controller?.animateTo(
+        queue.length - 4 * 72 + 12,
+        curve: Curves.linear,
+        duration: const Duration(
+          milliseconds: 350,
+        ),
+      );
+    }
+    return;
+  }
+
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<QueueState>(
@@ -1169,6 +1195,16 @@ class NowPlayingStream extends StatelessWidget {
       builder: (context, snapshot) {
         final queueState = snapshot.data ?? QueueState.empty;
         final queue = queueState.queue;
+        final int queueStateIndex = queueState.queueIndex ?? 0;
+        final num queuePosition = queue.length - queueStateIndex;
+        WidgetsBinding.instance.addPostFrameCallback(
+          (_) => _updateScrollController(
+          scrollController,
+          queueState.queueIndex,
+          queuePosition.toInt(),
+          queue,
+          ),
+        );
 
         return ReorderableListView.builder(
           header: SizedBox(
@@ -1365,6 +1401,12 @@ class NowPlayingStream extends StatelessWidget {
                   ),
                   onTap: () {
                     audioHandler.skipToQueueItem(index);
+                    _updateScrollController(
+                      scrollController,
+                      queueState.queueIndex,
+                      queuePosition.toInt(),
+                      queue,
+                    );
                   },
                 ),
               ),

--- a/lib/Screens/Player/audioplayer.dart
+++ b/lib/Screens/Player/audioplayer.dart
@@ -1163,22 +1163,22 @@ class NowPlayingStream extends StatelessWidget {
   });
 
   void _updateScrollController(
-    ScrollController? _controller,
-    int? itemIndex,
+    ScrollController? controller,
+    int itemIndex,
     int queuePosition,
-    queue,
+    int queueLength,
   ) {
     if (queuePosition > 3) {
-      _controller?.animateTo(
-        itemIndex! * 72 + 12,
+      controller?.animateTo(
+        itemIndex * 72 + 12,
         curve: Curves.linear,
         duration: const Duration(
           milliseconds: 350,
         ),
       );
-    } else if (queue.length - queuePosition < 5) {
-      _controller?.animateTo(
-        queue.length - 4 * 72 + 12,
+    } else if (queuePosition < 4 && queueLength > 4) {
+      controller?.animateTo(
+        (queueLength - 4) * 72 + 12,
         curve: Curves.linear,
         duration: const Duration(
           milliseconds: 350,
@@ -1199,10 +1199,10 @@ class NowPlayingStream extends StatelessWidget {
         final num queuePosition = queue.length - queueStateIndex;
         WidgetsBinding.instance.addPostFrameCallback(
           (_) => _updateScrollController(
-          scrollController,
-          queueState.queueIndex,
-          queuePosition.toInt(),
-          queue,
+            scrollController,
+            queueState.queueIndex ?? 0,
+            queuePosition.toInt(),
+            queue.length,
           ),
         );
 
@@ -1403,9 +1403,9 @@ class NowPlayingStream extends StatelessWidget {
                     audioHandler.skipToQueueItem(index);
                     _updateScrollController(
                       scrollController,
-                      queueState.queueIndex,
+                      queueState.queueIndex ?? 0,
                       queuePosition.toInt(),
-                      queue,
+                      queue.length,
                     );
                   },
                 ),


### PR DESCRIPTION
Hello!

I have finally managed to implement the autoscroll feature in the `SlidingUpPanel`. I used a `ValueListenableBuilder` and utilized the gradientColor as the `valueListenable`.

Now:

*   When the user plays a new song, it autoscrolls if the player is open or closed, but only once.
*   When the song played is one of the 3 last, it doesn't autoscroll because otherwise it was buggy and scrolled under the \`List\`…
*   One thing is when the song played isn't the first one and coming from another screen, the `SlidingUpPanel` autoscrolls after the user moves the List

Also, there was a problem with the height of the `Text` but I have added 12dp plus the index \* height of a ListTile (72dp) so now this is fixed!
Besides, I don't know if an option to enable/disable it is necessary here.