### PR TITLE
Fix repeat mode causes incorrect seekbar time

### DIFF
--- a/lib/Screens/Player/audioplayer.dart
+++ b/lib/Screens/Player/audioplayer.dart
@@ -2042,12 +2042,12 @@ class NameNControls extends StatelessWidget {
                                     icon: icons[index],
                                     tooltip:
                                         'Repeat ${texts[(index + 1) % texts.length]}',
-                                    onPressed: () {
-                                      Hive.box('settings').put(
+                                    onPressed: () async {
+                                      await Hive.box('settings').put(
                                         'repeatMode',
                                         texts[(index + 1) % texts.length],
                                       );
-                                      audioHandler.setRepeatMode(
+                                      await audioHandler.setRepeatMode(
                                         cycleModes[
                                             (cycleModes.indexOf(repeatMode) +
                                                     1) %

--- a/lib/Services/audio_service.dart
+++ b/lib/Services/audio_service.dart
@@ -196,6 +196,9 @@ class AudioPlayerHandlerImpl extends BaseAudioHandler
     _player!.shuffleModeEnabledStream
         .listen((enabled) => _broadcastState(_player!.playbackEvent));
 
+    _player!.loopModeStream
+        .listen((event) => _broadcastState(_player!.playbackEvent));
+
     _player!.processingStateStream.listen((state) {
       if (state == ProcessingState.completed) {
         stop();


### PR DESCRIPTION
Fixes #293

I noticed there were a couple extra lines of code for shuffle that didn't exist for repeat mode - I added those in and verified that repeat did not mess with the seekbar (like it was doing before).

Also worth noting that pressing shuffle seemed to "fix" the incorrect time from the repeat button weirdness, so it seemed like repeat mode code needed to more closely resemble the shuffle implementation.