### PR TITLE
Fixed a bug -> which appeared on first initialization of app

### DIFF
--- a/lib/Services/audio_service.dart
+++ b/lib/Services/audio_service.dart
@@ -220,6 +220,8 @@ class AudioPlayerHandlerImpl extends BaseAudioHandler
         .pipe(queue);
 
     if (loadStart) {
+      // final lastQueueListBox = await Hive.box('cache')
+      //     .get('lastQueue', defaultValue: []);
       final List lastQueueList = await Hive.box('cache')
           .get('lastQueue', defaultValue: [])?.toList() as List;
 
@@ -232,15 +234,18 @@ class AudioPlayerHandlerImpl extends BaseAudioHandler
       final List<MediaItem> lastQueue = lastQueueList
           .map((e) => MediaItemConverter.mapToMediaItem(e as Map))
           .toList();
+      if (lastQueue.isEmpty) {
+        await _player!.setAudioSource(_playlist, preload: false);
+      } else {
+        await _playlist.addAll(_itemsToSources(lastQueue));
+        await _player!.setAudioSource(
+          _playlist,
+          // commented out due to some bug in audio_service which causes app to freeze
 
-      await _playlist.addAll(_itemsToSources(lastQueue));
-      await _player!.setAudioSource(
-        _playlist,
-        // commented out due to some bug in audio_service which causes app to freeze
-
-        // initialIndex: lastIndex,
-        // initialPosition: Duration(seconds: lastPos),
-      );
+          // initialIndex: lastIndex,
+          // initialPosition: Duration(seconds: lastPos),
+        );
+      }
     } else {
       await _player!.setAudioSource(_playlist, preload: false);
     }

--- a/lib/Services/audio_service.dart
+++ b/lib/Services/audio_service.dart
@@ -220,8 +220,6 @@ class AudioPlayerHandlerImpl extends BaseAudioHandler
         .pipe(queue);
 
     if (loadStart) {
-      // final lastQueueListBox = await Hive.box('cache')
-      //     .get('lastQueue', defaultValue: []);
       final List lastQueueList = await Hive.box('cache')
           .get('lastQueue', defaultValue: [])?.toList() as List;
 


### PR DESCRIPTION
On first starting of app in debug mode, app freezes because `_player` tried to `setAudioSource` with an empty playlist and preload to `true`.
I added a check if `listQueue` is empty by introducing this code:
```
if (lastQueue.isEmpty) {
        await _player!.setAudioSource(_playlist, preload: false);
      } else {
        await _playlist.addAll(_itemsToSources(lastQueue));
        await _player!.setAudioSource(
          _playlist,
        );
}
```