### PR TITLE
Use devices/system language as default on first launch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -146,8 +146,6 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
-    final String lang =
-        Hive.box('settings').get('lang', defaultValue: 'English') as String;
     final Map<String, String> codes = {
       'Chinese': 'zh',
       'Czech': 'cs',
@@ -169,7 +167,14 @@ class _MyAppState extends State<MyApp> {
       'Ukrainian': 'uk',
       'Urdu': 'ur',
     };
-    _locale = Locale(codes[lang]!);
+    final String systemLangCode = Platform.localeName.substring(0, 2);
+    if (codes.values.contains(systemLangCode)) {
+      _locale = Locale(systemLangCode);
+    } else {
+      final String lang =
+          Hive.box('settings').get('lang', defaultValue: 'English') as String;
+      _locale = Locale(codes[lang]!);
+    }
 
     AppTheme.currentTheme.addListener(() {
       setState(() {});


### PR DESCRIPTION
By default, I think the app should show the UI in the system language, if it's supported.  For example, if my system language is Russian, I want to see this app displayed in Russian from the start. I may not know English in order to be able to switch the language later in the app settings.

So I added a bit of code to detect the default language used by the system. The language code is obtained via `Platform.localeName`, which stores something like `en`, `en_US` or `en-US.UTF-8` according to the docs, so normally we should be able to get the language code by extracting the first 2 characters. This isn't always the case, as pointed out by [the documentation](https://api.flutter.dev/flutter/dart-io/Platform/localeName.html), on some systems this property contains the value of the `LANG` variable, which can be set to something else other than a valid language code or locale name (IMO this is very rare and non-standard).

Tested this fix on Android and iOS with the Russian language and it appears to work fine.

There is still some room for improvement though. For example, the list of languages that you would like to listen music in is still displayed in English - ideally it should be translated to the chosen language I think.