### PR TITLE
Fix YouTube search and home in France

### DIFF
--- a/lib/Services/youtube_services.dart
+++ b/lib/Services/youtube_services.dart
@@ -358,7 +358,7 @@ class YouTubeServices {
   }
 
   Future<List<Video>> fetchSearchResults(String query) async {
-    final List<Video> searchResults = await yt.search.getVideos(query);
+    final List<Video> searchResults = await yt.search.search(query);
 
     // Uri link = Uri.https(searchAuthority, searchPath, {"search_query": query});
     // final Response response = await get(link);

--- a/lib/Services/youtube_services.dart
+++ b/lib/Services/youtube_services.dart
@@ -79,14 +79,25 @@ class YouTubeServices {
             'Highlights from Global Citizen Live') {
           return {
             'title': element['title']['runs'][0]['text'],
-            'playlists': element['title']['runs'][0]['text'].trim() == 'Charts'
+            'playlists': element['title']['runs'][0]['text'].trim() ==
+                        'Charts' ||
+                    element['title']['runs'][0]['text'].trim() == 'Classements'
                 ? formatChartItems(
                     element['content']['horizontalListRenderer']['items']
                         as List,
                   )
                 : element['title']['runs'][0]['text']
-                        .toString()
-                        .contains('Music Videos')
+                            .toString()
+                            .contains('Music Videos') ||
+                        element['title']['runs'][0]['text']
+                            .toString()
+                            .contains('Nouveaux clips') ||
+                        element['title']['runs'][0]['text']
+                            .toString()
+                            .contains('En Musique Avec Moi') ||
+                        element['title']['runs'][0]['text']
+                            .toString()
+                            .contains('Performances Uniques')
                     ? formatVideoItems(
                         element['content']['horizontalListRenderer']['items']
                             as List,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -309,7 +309,7 @@ packages:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.3"
+    version: "2.2.0"
   functions_client:
     dependency: transitive
     description:
@@ -386,7 +386,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
+    version: "3.3.0"
   intl:
     dependency: transitive
     description:
@@ -944,7 +944,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.1"
+    version: "6.1.0"
   yaml:
     dependency: transitive
     description:
@@ -958,7 +958,7 @@ packages:
       name: youtube_explode_dart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.7+1"
+    version: "1.12.3"
 sdks:
   dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   supabase: ^1.1.1
   url_launcher: ^6.1.7
   uuid: ^3.0.7
-  youtube_explode_dart: 1.10.7+1
+  youtube_explode_dart: ^1.12.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hello,
A small PR to update `youtube_explode_dart` to 1.12.3 in order to fix YouTube search issue.
Also, I have added a basic support for the YouTube Music Home in France. The name of each category is translated: is `formatItems` used? Otherwise, a loop could be possible for each `videoItems` without relying on the title of the category.