### PR TITLE
Remove yt music check to add it to recently played list

### DIFF
--- a/lib/Services/audio_service.dart
+++ b/lib/Services/audio_service.dart
@@ -163,10 +163,8 @@ class AudioPlayerHandlerImpl extends BaseAudioHandler
       }
 
       if (item.artUri.toString().startsWith('http')) {
-        if (item.genre != 'YouTube') {
-          addRecentlyPlayed(item);
-          _recentSubject.add([item]);
-        }
+        addRecentlyPlayed(item);
+        _recentSubject.add([item]);
 
         if (recommend && item.extras!['autoplay'] as bool) {
           final List<MediaItem> mediaQueue = queue.value;


### PR DESCRIPTION
**Description** - 

- Fixes #553 
- Removed the check which avoid adding YT music to the recently played list before storing in cache.
- Why it was added and why we can remove it now has been explained by @Sangwan5688 [here](https://github.com/Sangwan5688/BlackHole/issues/553#issuecomment-1510406079).

**Testing** - 
- Build successful.
- Able to use the app and its features.
- Played Youtube music and it was added to Last Session tab.
- Opened the app after more than 6hrs and opened the youtube music from last session and was able to play it successfully.