### PR TITLE
Automate youtube songs change in ios and mac

### DIFF
--- a/lib/Services/audio_service.dart
+++ b/lib/Services/audio_service.dart
@@ -73,7 +73,6 @@ class AudioPlayerHandlerImpl extends BaseAudioHandler
   @override
   final BehaviorSubject<double> speed = BehaviorSubject.seeded(1.0);
   final _mediaItemExpando = Expando<MediaItem>();
-  late MediaItem _currentMediaItem;
 
   Stream<List<IndexedAudioSource>> get _effectiveSequence => Rx.combineLatest3<
               List<IndexedAudioSource>?,
@@ -196,7 +195,6 @@ class AudioPlayerHandlerImpl extends BaseAudioHandler
         Hive.box('settings').get('loadStart', defaultValue: true) as bool;
 
     mediaItem.whereType<MediaItem>().listen((item) {
-      _currentMediaItem = item;
       if (count != null) {
         count = count! - 1;
         if (count! <= 0) {
@@ -286,7 +284,7 @@ class AudioPlayerHandlerImpl extends BaseAudioHandler
     if (Platform.isIOS || Platform.isMacOS) {
       _player!.positionStream.listen((position) {
         final itemIndex =
-            queue.value.indexWhere((item) => item.id == _currentMediaItem.id);
+            queue.value.indexWhere((item) => item.id == mediaItem.value?.id);
         if (itemIndex != -1) {
           final item = queue.value[itemIndex];
           if (item.genre == 'YouTube' && position >= item.duration!) {

--- a/lib/Services/audio_service.dart
+++ b/lib/Services/audio_service.dart
@@ -288,7 +288,8 @@ class AudioPlayerHandlerImpl extends BaseAudioHandler
         if (itemIndex != -1) {
           final item = queue.value[itemIndex];
           if (item.genre == 'YouTube' && position >= item.duration!) {
-            if (itemIndex + 1 == queue.value.length) {
+            if (playbackState.value.repeatMode.name == 'None' &&
+                itemIndex + 1 == queue.value.length) {
               _player!.pause();
               _player!.seek(Duration.zero, index: 0);
             } else {

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -99,7 +99,7 @@ SPEC CHECKSUMS:
   just_audio: 9b67ca7b97c61cfc9784ea23cd8cc55eb226d489
   metadata_god: eceae399d0020475069a5cebc35943ce8562b5d7
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
-  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
+  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
   sqflite: a5789cceda41d54d23f31d6de539d65bb14100ea
@@ -108,4 +108,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.14.2


### PR DESCRIPTION
Hi! debugging a lot I realize that there would be something wrong with the format of the files downloaded with the youtube_explode_dart library or the youtube songs (videos) themselves on ios and mac.
I tried changing the file of the downloaded song, with another one downloaded from another webpage, and it made the change to the song automatically.

I don't find another way of doing this for now, and I didn't find another plugin that can help with downloading the youtube songs.

With this approach, you can sometimes listen to some microceconds two times of the start of the next song.

Do you find another way to improve this?

Related to: issue #538 